### PR TITLE
Added TryGetProperty to AstNode.

### DIFF
--- a/Source/Devsense.PHP.Parser/Ast/LangElement.cs
+++ b/Source/Devsense.PHP.Parser/Ast/LangElement.cs
@@ -61,6 +61,14 @@ namespace Devsense.PHP.Syntax.Ast
             }
         }
 
+        bool IPropertyCollection.TryGetProperty<T>(out T value)
+        {
+            lock (this)
+            {
+                return _properties.TryGetProperty<T>(out value);
+            }
+        }
+
         public void SetProperty<T>(T value)
         {
             lock (this)
@@ -77,19 +85,19 @@ namespace Devsense.PHP.Syntax.Ast
             }
         }
 
+        public bool TryGetProperty<T>(out T value)
+        {
+            lock (this)
+            {
+                return _properties.TryGetProperty<T>(out value);
+            }
+        }
+
         bool IPropertyCollection.TryGetProperty(object key, out object value)
         {
             lock (this)
             {
                 return _properties.TryGetProperty(key, out value);
-            }
-        }
-
-        bool IPropertyCollection.TryGetProperty<T>(out T value)
-        {
-            lock (this)
-            {
-                return _properties.TryGetProperty<T>(out value);
             }
         }
 


### PR DESCRIPTION
- no need to go explicitly trough node.Properties.TryGetProperty(...)
- the diff looks weird but it's only adding public TryGetProperty & moving the explicit interface one.