### PR TITLE
Cross target .NETSTANDARD 2.0

### DIFF
--- a/Source/Devsense.PHP.Parser/Devsense.PHP.Parser.csproj
+++ b/Source/Devsense.PHP.Parser/Devsense.PHP.Parser.csproj
@@ -16,7 +16,7 @@
     <FileAlignment>512</FileAlignment>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <TargetFrameworks>netstandard1.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;net45</TargetFrameworks>
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Cross target .NETSTANDARD2.0 to eliminate dependencies on modern runtimes including .NETCOREAPP2.0.
